### PR TITLE
Bump net.sourceforge.pmd:pmd-core

### DIFF
--- a/java-starter/pom.xml
+++ b/java-starter/pom.xml
@@ -65,7 +65,8 @@
         <extra-enforcer-rules.version>1.9.0</extra-enforcer-rules.version>
 
         <maven-pmd-plugin.version>3.26.0</maven-pmd-plugin.version>
-        <pmd.version>7.2.0</pmd.version>
+        <pmd.version>7.12.0</pmd.version>
+        <pmd-compat6.version>7.2.0</pmd-compat6.version>
 
         <spotbugs-maven-plugin.version>4.9.3.0</spotbugs-maven-plugin.version>
         <spotbugs.version>4.9.3</spotbugs.version>
@@ -327,7 +328,7 @@
                         <dependency>
                             <groupId>net.sourceforge.pmd</groupId>
                             <artifactId>pmd-compat6</artifactId>
-                            <version>${pmd.version}</version>
+                            <version>${pmd-compat6.version}</version>
                         </dependency>
 
                         <dependency>


### PR DESCRIPTION
Bumps the maven group with 1 update in the /java-starter directory: [net.sourceforge.pmd:pmd-core](https://github.com/pmd/pmd).

Updates `net.sourceforge.pmd:pmd-core` from 7.2.0 to 7.10.0
- [Release notes](https://github.com/pmd/pmd/releases)
- [Changelog](https://github.com/pmd/pmd/blob/main/docs/render_release_notes.rb)
- [Commits](https://github.com/pmd/pmd/compare/pmd_releases/7.2.0...pmd_releases/7.10.0)

---
updated-dependencies:
- dependency-name: net.sourceforge.pmd:pmd-core dependency-version: 7.10.0 dependency-type: direct:production dependency-group: maven ...